### PR TITLE
Dịch lại "Skip non-Vietnamese:"

### DIFF
--- a/config-gui/locales/vi_VN.ts
+++ b/config-gui/locales/vi_VN.ts
@@ -30,7 +30,7 @@
     <message>
         <location filename="controller.ui" line="150"/>
         <source>Skip non-Vietnamese:</source>
-        <translation>Bỏ qua những từ không đúng tiếng Việt: </translation>
+        <translation>Tự động trả về tiếng Anh:</translation>
     </message>
     <message>
         <location filename="controller.ui" line="164"/>


### PR DESCRIPTION
thành "Tự động trả về tiếng Anh:" cho ngắn gọn, dễ hiểu.
