### PR TITLE
Enable skip-non-vietnamese by default

### DIFF
--- a/bogo/bogo.py
+++ b/bogo/bogo.py
@@ -38,7 +38,7 @@ class Action:
 default_config = {
     "input-method": "telex",
     "output-charset": "utf-8",
-    "skip-non-vietnamese" : False,
+    "skip-non-vietnamese" : True,
     "default-input-methods": {
         "simple-telex": {
             "a": "a^",


### PR DESCRIPTION
This nice feature should be enabled by default.
